### PR TITLE
cofi 0.2.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cofi" %}
-{% set version = "0.2.9" %}
+{% set version = "0.2.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cofi-{{ version }}.tar.gz
-  sha256: 7419b62b13dffc2d15dcb68203d5389e23f7e663e3865781effb0408033f8c5f
+  sha256: f9f73f1d75773e6ac8a1666d17e1d2c9ab48149a6ef1b03fb4a678791e06b488
 
 build:
   noarch: python
@@ -16,19 +16,20 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.10
     - pip
     - versioningit
   run:
-    - python >=3.7
-    - numpy >=1.18
-    - scipy >=1.0.0
-    - emcee >=3.1.0
-    - arviz >=0.9.0
-    - findiff >=0.7.0
-    - pytorch >=1.10
+    - python >=3.10
+    - numpy >=1.23.0
+    - scipy >=1.9.0
+    - emcee >=3.1.5
+    - arviz >=0.23.0
+    - findiff >=0.10.0
+    - pytorch >=2.0.0
     - bayesbay >=0.3.0
-    - neighpy >=0.1.2
+    - neighpy >=0.1.5,!=0.1.8
+    - mealpy >=3.0.0,<3.0.3
 
 test:
   imports:
@@ -50,3 +51,4 @@ extra:
   recipe-maintainers:
     - JuergHauser
     - jwhhh
+    - ChaiThere

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cofi" %}
 {% set version = "0.2.12" %}
-{% set python_min = "3.10" %}
+{% set python_min = "3.11" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cofi-{{ version }}.tar.gz
+  url: https://files.pythonhosted.org/packages/source/{{ name[0] }}/{{ name }}/cofi-{{ version }}.tar.gz
   sha256: f9f73f1d75773e6ac8a1666d17e1d2c9ab48149a6ef1b03fb4a678791e06b488
 
 build:
@@ -16,11 +16,12 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
+    - setuptools >=42
     - versioningit
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - numpy >=1.23.0
     - scipy >=1.9.0
     - emcee >=3.1.5
@@ -38,6 +39,7 @@ test:
     - pip check
   requires:
     - pip
+    - python {{ python_min }}
 
 about:
   home: https://github.com/inlab-geo/cofi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "cofi" %}
 {% set version = "0.2.12" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
This bumps `cofi` to 0.2.12, superseding the stale automated bump PR #21.

## Why not just #21

#21 (`regro-cf-autotick-bot`, opened 2026-07-01) is a plain `version`/`sha256` bump and fails CI before it even reaches dependency resolution:

```
pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.build_meta'
```

It also doesn't address the dependency drift between 0.2.9 (currently pinned here) and 0.2.12:

- `python` floor: `>=3.7` → `>=3.10`
- `numpy`, `scipy`, `emcee`, `arviz`, `findiff`, `pytorch` pins all bumped to match cofi 0.2.12's actual `requires_dist`
- `neighpy` gets an added `!=0.1.8` exclusion
- cofi 0.2.11+ added a new hard runtime dependency, `mealpy`, not previously in this recipe at all

## mealpy dependency

`mealpy` (and its own dependency `opfunu`) weren't on conda-forge, so getting here required packaging both first:

- `opfunu`: merged and live — conda-forge/staged-recipes#34551
- `mealpy`: open, all CI green, pending review — conda-forge/staged-recipes#34552

**CI on this PR will fail on the `mealpy` solve step until #34552 merges and builds** — that's expected, not a regression. I'll follow up once it's live.

## Maintainer addition

This PR adds `ChaiThere` (me) to `extra.recipe-maintainers`, since I put together this bump and now maintain the upstream `opfunu`/`mealpy` conda-forge recipes that `cofi` depends on. If you're comfortable with it, supporting that addition when reviewing would help keep this dependency chain in sync going forward — no worries at all if you'd rather not, just flagging it explicitly rather than sneaking it into the diff.

cc @JuergHauser @jwhhh — would appreciate a review when you have a chance.
